### PR TITLE
Replace links to latest with stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Each example has an README.md that explains what each project does and how to wo
 
 ## What will I find in this repository?
 
-- We recommend you start with [`kedro-tutorial`](https://github.com/quantumblacklabs/kedro-examples/tree/master/kedro-tutorial), which is the complete version of the [Space Flights tutorial](https://kedro.readthedocs.io/en/latest/03_tutorial/02_tutorial_template.html) described in the Kedro [documentation](https://kedro.readthedocs.io) and includes the data necessary to run the project
+- We recommend you start with [`kedro-tutorial`](https://github.com/quantumblacklabs/kedro-examples/tree/master/kedro-tutorial), which is the complete version of the [Space Flights tutorial](https://kedro.readthedocs.io/en/stable/03_tutorial/02_tutorial_template.html) described in the Kedro [documentation](https://kedro.readthedocs.io) and includes the data necessary to run the project
 - Documentation that you can use to deliver Kedro training in [`kedro-training`](https://github.com/quantumblacklabs/kedro-examples/tree/master/kedro-training)
 
 ## Where can I find more `kedro-examples`?

--- a/kedro-exercises/spaceflight/conf/README.md
+++ b/kedro-exercises/spaceflight/conf/README.md
@@ -23,4 +23,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 
 
 # Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/latest/04_user_guide/03_configuration.html).
+You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/04_user_guide/03_configuration.html).

--- a/kedro-training/README.md
+++ b/kedro-training/README.md
@@ -1,6 +1,6 @@
 # Kedro Training
 
-This repository contains training materials that will teach you how to use [Kedro](https://github.com/quantumblacklabs/kedro/). This content is based on the [Spaceflights tutorial](https://kedro.readthedocs.io/en/latest/03_tutorial/02_tutorial_template.html) specified in our documentation.
+This repository contains training materials that will teach you how to use [Kedro](https://github.com/quantumblacklabs/kedro/). This content is based on the [Spaceflights tutorial](https://kedro.readthedocs.io/en/stable/03_tutorial/02_tutorial_template.html) specified in our documentation.
 
 ## Scenario
 
@@ -18,4 +18,4 @@ This tutorial covers:
 
 ## License
 
-This work, "Kedro Training", is a derivative of the ["Airflow Tutorial"](https://github.com/trallard/airflow-tutorial/) by [Tania Allard](https://github.com/trallard), used under CC BY-SA 4.0. We derived content from the [`README.md`](https://github.com/trallard/airflow-tutorial/blob/master/README.md) and ["Setup"](https://airflow-tutorial.readthedocs.io/en/latest/setup.html). "Kedro Training" is licensed under CC BY-SA 4.0 by QuantumBlack Visual Analytics Limited.
+This work, "Kedro Training", is a derivative of the ["Airflow Tutorial"](https://github.com/trallard/airflow-tutorial/) by [Tania Allard](https://github.com/trallard), used under CC BY-SA 4.0. We derived content from the [`README.md`](https://github.com/trallard/airflow-tutorial/blob/master/README.md) and ["Setup"](https://airflow-tutorial.readthedocs.io/en/stable/setup.html). "Kedro Training" is licensed under CC BY-SA 4.0 by QuantumBlack Visual Analytics Limited.

--- a/kedro-training/docs/04_new_project.md
+++ b/kedro-training/docs/04_new_project.md
@@ -100,7 +100,7 @@ This structure may seem overwhelming at the first glance, but rest assured that 
 | Folder | Description | Priority |
 | ------ | ----------- | -------- |
 | `conf` | The `conf` directory is the place where all your project configuration is located. Kedro has a powerful built-in mechanism for loading configuration. Using `conf` encourages a clear and strict separation between project code and configuration. | Core |
-| `data` | A place to store _local_ project data according to a suggested [Data Engineering Convention](https://kedro.readthedocs.io/en/latest/06_resources/01_faq.html#what-is-data-engineering-convention). For production workloads we do not recommend storing data locally, but rather utilising cloud storage (AWS S3, Azure Blob Storage), distributed file storage or database interfaces through Kedro's Data Catalog | Non-essential |
+| `data` | A place to store _local_ project data according to a suggested [Data Engineering Convention](https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention). For production workloads we do not recommend storing data locally, but rather utilising cloud storage (AWS S3, Azure Blob Storage), distributed file storage or database interfaces through Kedro's Data Catalog | Non-essential |
 | `docs` | `docs` is where your auto-generated project documentation is saved | Nice to have |
 | `logs` | A directory for your Kedro pipeline execution logs | Nice to have |
 | `notebooks` |  Kedro supports a Jupyter workflow, that allows you to experiment and iterate quickly on your models. `notebooks` is the folder where you can store your Jupyter Notebooks | Nice to have |
@@ -111,7 +111,7 @@ This structure may seem overwhelming at the first glance, but rest assured that 
 
 Source folder by default contains the following components:
 1. Your Kedro project Python package - `kedro_training` in this case
-2. `tests` folder with example unit tests; newly generated projects are preconfigured to run these tests using the [pytest framework](https://docs.pytest.org/en/latest/)
+2. `tests` folder with example unit tests; newly generated projects are preconfigured to run these tests using the [pytest framework](https://docs.pytest.org/en/stable/)
 3. `requirements.txt` file that contains all Python package dependencies
 4. `setup.py` - used by [Python Distutils](https://docs.python.org/3/library/distutils.html) for packaging the project
 

--- a/kedro-training/docs/05_connecting-data-sources.md
+++ b/kedro-training/docs/05_connecting-data-sources.md
@@ -73,7 +73,7 @@ All Kedro projects have a `conf/base/catalog.yml` file where users register the 
 * Versioning (optional)
 * Any additional arguments (optional)
 
-Kedro supports a number of different data types, such as `csv`, which is implemented by `CSVLocalDataSet`. You can find all supported datasets in the API docs for ([core datasets](https://kedro.readthedocs.io/en/latest/kedro.io.html) and [contrib datasets](https://kedro.readthedocs.io/en/latest/kedro.contrib.io.html)). The difference between core and contrib dataset is that core datasets are well supported by Kedro team (e.g., all of them support data versioning), and contrib datasets were added by external contributors (e.g., some support data versioning).
+Kedro supports a number of different data types, such as `csv`, which is implemented by `CSVLocalDataSet`. You can find all supported datasets in the API docs for ([core datasets](https://kedro.readthedocs.io/en/stable/kedro.io.html) and [contrib datasets](https://kedro.readthedocs.io/en/stable/kedro.contrib.io.html)). The difference between core and contrib dataset is that core datasets are well supported by Kedro team (e.g., all of them support data versioning), and contrib datasets were added by external contributors (e.g., some support data versioning).
 
 Let’s start this process by registering the `csv` datasets by copying the following to the end of the `conf/base/catalog.yml` file:
 

--- a/kedro-training/docs/06_jupyter-notebook-workflow.md
+++ b/kedro-training/docs/06_jupyter-notebook-workflow.md
@@ -101,7 +101,7 @@ If you, however, want to parameterize the run, you can also specify the followin
 | Argument name | Accepted types | Description |
 | :--------: | :--------: | :----------- |
 | `tags` | `Iterable[str]` | Construct the pipeline using only nodes which have this tag attached. A node is included in the resulting pipeline if it contains _any_ of those tags | 
-| `runner` | `AbstractRunner` | An instance of Kedro [AbstractRunner](https://kedro.readthedocs.io/en/latest/kedro.runner.AbstractRunner.html); for example, can be an instance of a [ParallelRunner](https://kedro.readthedocs.io/en/latest/kedro.runner.ParallelRunner.html) |
+| `runner` | `AbstractRunner` | An instance of Kedro [AbstractRunner](https://kedro.readthedocs.io/en/stable/kedro.runner.AbstractRunner.html); for example, can be an instance of a [ParallelRunner](https://kedro.readthedocs.io/en/stable/kedro.runner.ParallelRunner.html) |
 | `node_names` | `Iterable[str]` | Run only nodes with specified names |
 | `from_nodes` | `Iterable[str]` | A list of node names which should be used as a starting point |
 | `to_nodes`   | `Iterable[str]` | A list of node names which should be used as an end point |

--- a/kedro-training/docs/08_transformers.md
+++ b/kedro-training/docs/08_transformers.md
@@ -1,6 +1,6 @@
 # Kedro transformers
 
-[Transformers](https://kedro.readthedocs.io/en/latest/04_user_guide/04_data_catalog.html#transforming-datasets) intercept the load and save operations on Kedro `DataSet`s. Some use cases that transformers enable include: performing data validation, tracking operation performance and converting a data format (although we would recommend [Transcoding](https://kedro.readthedocs.io/en/latest/04_user_guide/04_data_catalog.html#transcoding-datasets) for this). We will cover _tracking operation performance_ with the following: 
+[Transformers](https://kedro.readthedocs.io/en/stable/04_user_guide/04_data_catalog.html#transforming-datasets) intercept the load and save operations on Kedro `DataSet`s. Some use cases that transformers enable include: performing data validation, tracking operation performance and converting a data format (although we would recommend [Transcoding](https://kedro.readthedocs.io/en/stable/04_user_guide/04_data_catalog.html#transcoding-datasets) for this). We will cover _tracking operation performance_ with the following: 
 1. Applying built-in transformers for monitoring load and save operation latency
 2. Developing our own transformer for tracking memory consumption 
 

--- a/kedro-training/docs/09_versioning.md
+++ b/kedro-training/docs/09_versioning.md
@@ -26,7 +26,7 @@ regressor:
 
 This will save versioned pickle models everytime you run the pipeline.
 
-> *Note:* The list of the datasets supporting versioning can be find in [the documentation](https://kedro.readthedocs.io/en/latest/04_user_guide/08_advanced_io.html#supported-datasets).
+> *Note:* The list of the datasets supporting versioning can be find in [the documentation](https://kedro.readthedocs.io/en/stable/04_user_guide/08_advanced_io.html#supported-datasets).
 
 ## Loading a versioned dataset
 By default, the `DataCatalog` will load the latest version of the dataset. However, you can run the pipeline with a particular versioned data set with `--load-version` flag as follows:

--- a/kedro-tutorial/README.md
+++ b/kedro-tutorial/README.md
@@ -6,7 +6,7 @@ This is a tutorial project, which was generated using `Kedro 0.15.5`. It is the 
 
 The tutorial works through the steps necessary to create this project. To learn the most about Kedro, we recommend that you start with a blank template as the tutorial describes, and follow through all the working. However, if you prefer to read swiftly through the documentation and get to work on the code, you may want to clone this example because the steps have been done for you.
 
-To use this project, use `git clone` to clone it. You don’t need to create a new Kedro project. To make sure you have the required dependencies, run in your virtual environment (see [the documentation](https://kedro.readthedocs.io/en/latest/02_getting_started/01_prerequisites.html#python-virtual-environments) for how to set up your virtual environment):
+To use this project, use `git clone` to clone it. You don’t need to create a new Kedro project. To make sure you have the required dependencies, run in your virtual environment (see [the documentation](https://kedro.readthedocs.io/en/stable/02_getting_started/01_prerequisites.html#python-virtual-environments) for how to set up your virtual environment):
 
 ```bash
 pip install kedro==0.15.5

--- a/kedro-tutorial/conf/README.md
+++ b/kedro-tutorial/conf/README.md
@@ -23,4 +23,4 @@ WARNING: Please do not put access credentials in the base configuration folder.
 
 
 # Find out more
-You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/latest/04_user_guide/03_configuration.html).
+You can find out more about configuration from the [user guide documentation](https://kedro.readthedocs.io/en/stable/04_user_guide/03_configuration.html).


### PR DESCRIPTION
## Description
The training should point towards our latest released version of Kedro, not the develop branch. Noticed this whilst doing the Kedro training.

## Development notes
/s/latest/stable

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
