### PR TITLE
Pin kedro versions in tutorial

### DIFF
--- a/kedro-training/docs/03_install_kedro.md
+++ b/kedro-training/docs/03_install_kedro.md
@@ -7,7 +7,7 @@ Your installation instructions will be virtual environment dependent.
 Install Kedro using `pip`:
 
 ```bash
-pip install kedro
+pip install kedro==0.15.9
 ```
 
 ## Using `conda`
@@ -15,7 +15,7 @@ pip install kedro
 Install Kedro using `conda` from the `conda-forge` channel:
 
 ```bash
-conda install -c conda-forge kedro
+conda install -c conda-forge kedro==0.15.9
 ```
 
 ## `pipenv`
@@ -23,7 +23,7 @@ conda install -c conda-forge kedro
 Install Kedro using `pipenv`:
 
 ```bash
-pipenv install kedro
+pipenv install kedro==0.15.9
 ```
 
 ### Next section


### PR DESCRIPTION
## Description
This pins the kedro version in the "install kedro" section to the version specified by the tutorial so it can be used as a pre-requisite guide.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
